### PR TITLE
Removed auto-scroll on Get Involved tab

### DIFF
--- a/src/pages/GetInvolvedPage/GetInvolvedPage.js
+++ b/src/pages/GetInvolvedPage/GetInvolvedPage.js
@@ -14,20 +14,6 @@ type PropsType = {};
 export default class GetInvolvedPage extends React.Component<PropsType> {
   formsWrapperDiv: ?HTMLDivElement;
 
-  componentDidMount() {
-    this.scrollToForms();
-  }
-
-  componentDidUpdate() {
-    this.scrollToForms();
-  }
-
-  scrollToForms() {
-    if (this.formsWrapperDiv) {
-      smoothlyScrollToElement(this.formsWrapperDiv, SCROLL_DURATION);
-    }
-  }
-
   render() {
     const {
       header


### PR DESCRIPTION
Clicking on the Get Involved tab no longer auto-scrolls down the page